### PR TITLE
Implement latest brokerapi interface.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -130,7 +130,7 @@ var _ = Describe("nfsbroker Main", func() {
 			logger = lagertest.NewTestLogger("test-broker-main")
 		})
 		JustBeforeEach(func() {
-			env:=fmt.Sprintf(`
+			env := fmt.Sprintf(`
 				{
 					"postgresql":[
 						{
@@ -155,8 +155,8 @@ var _ = Describe("nfsbroker Main", func() {
 							"volume_mounts":[]
 						}
 					]
-				}`,port)
-			fakeOs.LookupEnvReturns(env,true)
+				}`, port)
+			fakeOs.LookupEnvReturns(env, true)
 		})
 
 		Context("when port is a string", func() {
@@ -247,6 +247,7 @@ var _ = Describe("nfsbroker Main", func() {
 
 		httpDoWithAuth := func(method, endpoint string, body io.ReadCloser) (*http.Response, error) {
 			req, err := http.NewRequest(method, "http://"+listenAddr+endpoint, body)
+			req.Header.Add("X-Broker-Api-Version", "2.14")
 			Expect(err).NotTo(HaveOccurred())
 
 			req.SetBasicAuth(username, password)
@@ -266,7 +267,7 @@ var _ = Describe("nfsbroker Main", func() {
 				args = append(args, "-serviceId", "someguid")
 			})
 
-			It("should pass arguments though to catalog", func() {
+			It("should pass arguments through to catalog", func() {
 				resp, err := httpDoWithAuth("GET", "/v2/catalog", nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(200))

--- a/nfsbroker/nfsbroker_test.go
+++ b/nfsbroker/nfsbroker_test.go
@@ -52,7 +52,8 @@ var _ = Describe("Broker", func() {
 
 		Context(".Services", func() {
 			It("returns the service catalog as appropriate", func() {
-				results := broker.Services(ctx)
+				results, err := broker.Services(ctx)
+				Expect(err).NotTo(HaveOccurred())
 				result := results[0]
 				Expect(result.ID).To(Equal("service-id"))
 				Expect(result.Name).To(Equal("service-name"))
@@ -113,9 +114,9 @@ var _ = Describe("Broker", func() {
 				Expect(fakeStore.SaveCallCount()).Should(BeNumerically(">", 0))
 			})
 
-			Context("when create service json contains uid and gid", func(){
+			Context("when create service json contains uid and gid", func() {
 				BeforeEach(func() {
-					configuration := map[string]interface{}{"share": "server/some-share","uid":"1","gid":2}
+					configuration := map[string]interface{}{"share": "server/some-share", "uid": "1", "gid": 2}
 					buf := &bytes.Buffer{}
 					_ = json.NewEncoder(buf).Encode(configuration)
 					provisionDetails = brokerapi.ProvisionDetails{PlanID: "Existing", RawParameters: json.RawMessage(buf.Bytes())}
@@ -123,7 +124,7 @@ var _ = Describe("Broker", func() {
 				It("should write uid and gid into state", func() {
 					count := fakeStore.CreateInstanceDetailsCallCount()
 					Expect(count).To(BeNumerically(">", 0))
-					_, details := fakeStore.CreateInstanceDetailsArgsForCall(count-1)
+					_, details := fakeStore.CreateInstanceDetailsArgsForCall(count - 1)
 					fp := details.ServiceFingerPrint.(map[string]interface{})
 					Expect(fp).NotTo(BeNil())
 					Expect(fp).To(HaveKeyWithValue("uid", "1"))
@@ -429,19 +430,19 @@ var _ = Describe("Broker", func() {
 				Expect(binding.VolumeMounts[0].Device.VolumeId).To(ContainSubstring("some-instance-id"))
 			})
 
-			Context("when the service instance contains uid and gid", func(){
-				BeforeEach(func(){
+			Context("when the service instance contains uid and gid", func() {
+				BeforeEach(func() {
 					serviceInstance := brokerstore.ServiceInstance{
 						ServiceID: serviceID,
 						ServiceFingerPrint: map[string]interface{}{
 							nfsbroker.SHARE_KEY: "server:/some-share",
-							"uid": "1",
-							"gid": 2,
+							"uid":               "1",
+							"gid":               2,
 						},
 					}
 					fakeStore.RetrieveInstanceDetailsReturns(serviceInstance, nil)
 				})
-				It("should favor the values in the bind configuration", func(){
+				It("should favor the values in the bind configuration", func() {
 					binding, err := broker.Bind(ctx, instanceID, "binding-id", bindDetails)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -455,15 +456,15 @@ var _ = Describe("Broker", func() {
 					Expect(v).To(Equal(gid))
 				})
 
-				Context("when the bind operation doesn't pass configuration", func(){
-					BeforeEach(func(){
+				Context("when the bind operation doesn't pass configuration", func() {
+					BeforeEach(func() {
 						bindDetails = brokerapi.BindDetails{
 							AppGUID:       "guid",
 							RawParameters: []byte(""),
 						}
 					})
 
-					It("should use uid and gid from the service instance configuration", func(){
+					It("should use uid and gid from the service instance configuration", func() {
 						binding, err := broker.Bind(ctx, "some-instance-id", "binding-id", bindDetails)
 						Expect(err).NotTo(HaveOccurred())
 						mc := binding.VolumeMounts[0].Device.MountConfig
@@ -477,28 +478,28 @@ var _ = Describe("Broker", func() {
 					})
 				})
 			})
-			Context("when the bind operation doesn't pass configuration", func(){
-				BeforeEach(func(){
+			Context("when the bind operation doesn't pass configuration", func() {
+				BeforeEach(func() {
 					bindDetails = brokerapi.BindDetails{
 						AppGUID:       "guid",
 						RawParameters: []byte(""),
 					}
 				})
 
-				It("should succeed", func(){
+				It("should succeed", func() {
 					_, err := broker.Bind(ctx, "some-instance-id", "binding-id", bindDetails)
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
-			Context("when the bind operation passes empty configuration", func(){
-				BeforeEach(func(){
+			Context("when the bind operation passes empty configuration", func() {
+				BeforeEach(func() {
 					bindDetails = brokerapi.BindDetails{
 						AppGUID:       "guid",
 						RawParameters: []byte("{}"),
 					}
 				})
 
-				It("should succeed", func(){
+				It("should succeed", func() {
 					_, err := broker.Bind(ctx, "some-instance-id", "binding-id", bindDetails)
 					Expect(err).NotTo(HaveOccurred())
 				})


### PR DESCRIPTION
I noticed that `nfs-volume-release` pins to an older version of `brokerapi`. Current `brokerapi` has changed the broker interface again. This patch implements the latest broker interface.