### PR TITLE
allow specifying uaa creds from env

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,6 +148,15 @@ func parseCommandLine() {
 func parseEnvironment() {
 	username, _ = os.LookupEnv("USERNAME")
 	password, _ = os.LookupEnv("PASSWORD")
+	uaaClientSecretString, _ := os.LookupEnv("UAA_CLIENT_SECRET")
+	if uaaClientSecretString != "" {
+		uaaClientSecret = &uaaClientSecretString
+	}
+	uaaClientIDString, _ := os.LookupEnv("UAA_CLIENT_ID")
+	if uaaClientIDString != "" {
+		uaaClientSecret = &uaaClientIDString
+	}
+
 }
 
 func checkParams() {


### PR DESCRIPTION
the binary currently only accepts uaa creds via cli args. that's bad because that leaves no option of starting the broker without potentially leaking creds through the linux audit system.

The code already allows to set the broker user and pass through ENV VARS. This adds the parsing of ENV VARS for UAA related creds.

UAA_CLIENT_ID
UAA_CLIENT_SECRET

Since the env parsing happens right after parsing the flags, the introduced ENV VARS take precedence over the values provided via the flags.